### PR TITLE
Add containerization for production use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.git
+**/.vscode
+**/__pycache__
+**/db.sqlite3
+**/.venv
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Stage for building the React project.
+# We don't need node.js in our runtime stage.
+FROM node:18-alpine
+
+COPY react /home/react
+WORKDIR /home/react
+ENV BASE_URL /static/
+RUN npm i
+RUN npm run build
+
+# Runtime stage
+FROM python:3.11-alpine
+
+# Install Django backend
+COPY backend /home/inventory_management/backend
+WORKDIR /home/inventory_management/backend
+RUN pip install -r requirements.txt
+ENV DJANGO_DEBUG False
+RUN python manage.py migrate
+
+# Move all static files to /home/inventory_management/static
+COPY --from=0 /home/react/dist /home/inventory_management/react/dist
+RUN rm -rf /home/inventory_management/static
+RUN python manage.py collectstatic
+RUN rm -rf /home/inventory_management/react
+
+EXPOSE 8000
+ENTRYPOINT ["gunicorn", "backend.wsgi", "--bind", "0.0.0.0:8000"]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -20,13 +21,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-_xv9&)k0h-f8!6(ydfn@o#niud@bl20oyh5_g&%co@jkt-ub06'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-_xv9&)k0h-f8!6(ydfn@o#niud@bl20oyh5_g&%co@jkt-ub06')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
 
 CORS_ORIGIN_ALLOW_ALL = DEBUG
 
+# This setting is only used when DEBUG = False
+ALLOWED_HOSTS = ['.localhost', '127.0.0.1', '[::1]']
 
 # Application definition
 
@@ -120,7 +123,13 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
+STATIC_ROOT = BASE_DIR.parent / "static"
+
 STATIC_URL = 'static/'
+
+STATICFILES_DIRS = [
+    BASE_DIR.parent / "react/dist"
+]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.shortcuts import redirect
+from django.urls import include, path
 
 urlpatterns = [
-    path('', include('db_access.urls')),
+    path('', lambda request: redirect("static/index.html", permanent=True)),
+    path('api/', include('db_access.urls')),
     path('admin/', admin.site.urls),
     path('test/', include('test_app.urls'))
 ]

--- a/backend/db_access/admin.py
+++ b/backend/db_access/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
+from .models import Delivery, Transaction, Brand, BrandDelivery
 
 # Register your models here.
+
+admin.site.register([Delivery, Transaction, Brand])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 django
 djangorestframework
 django-cors-headers
+gunicorn

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+services:
+  web:
+    build: .
+    expose:
+      - 8000
+    volumes:
+      - static_volume:/home/inventory_management/static
+  nginx:
+    build: ./nginx
+    ports:
+      - 80:80
+    volumes:
+      - static_volume:/home/inventory_management/static
+    depends_on:
+      - web
+volumes:
+  static_volume:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:stable-alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d
+
+EXPOSE 80

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,20 @@
+upstream web_app {
+    server web:8000;
+}
+
+server {
+
+    listen 80;
+
+    location /static/ {
+        alias /home/inventory_management/static/;
+    }
+
+    location / {
+        proxy_pass http://web_app;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+}

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@types/node": "^20.5.9",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -947,6 +948,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -3650,6 +3657,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
       "dev": true
     },
     "@types/prop-types": {

--- a/react/package.json
+++ b/react/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^20.5.9",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/react/src/constants.ts
+++ b/react/src/constants.ts
@@ -1,1 +1,1 @@
-export const API_URL = "http://localhost:8000"
+export const API_URL = import.meta.env.PROD ? window.location.origin : "http://localhost:8000";

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: process.env.BASE_URL ?? "/",
   plugins: [react()],
 })


### PR DESCRIPTION
Currently the application only runs via the development servers of both Django and Vite. These should obviously not be used in production. The React code can simply be built into static files using `npm run build` so this part is very straightforward. However, to deploy these files in addition to the Django application we need nginx to direct request to either the static files or the server running Django (gunicorn). This requires quite a bit of configuration which is why this PR adds a `docker-compose.yaml` which deals with all this configuration.